### PR TITLE
20140224 - Added support for rebbot_suggested. Mimicing spacewalk server...

### DIFF
--- a/errata-import.pl
+++ b/errata-import.pl
@@ -42,6 +42,8 @@
 # 20141002 - Fixed --exclude-errata feature
 # 20141007 - Fixed supportedapi array (Thanks, Christian)
 # 20141023 - Added support for Ubuntu USN Errata
+# 20140224 - Added support for rebbot_suggested. 
+#            Mimicing spacewalk server incorrect naming converntions, to match all packages.
 #
 # To do:
 # - Add CVEs to Errata (using errata.set_details)     [ DONE! ]
@@ -455,9 +457,9 @@ foreach $advisory (sort(keys(%{$xml}))) {
     
     # Find package IDs mentioned in errata
     &find_packages($advisory);
-
-    # Create Errata Info hash
-    %erratainfo = ( "synopsis"         => "$xml->{$advisory}->{synopsis}",
+    
+# Create Errata Info hash
+%erratainfo = ( "synopsis"         => "$xml->{$advisory}->{synopsis}",
                     "advisory_name"    => "$advid",
                     "advisory_release" => int($xml->{$advisory}->{release}),
                     "advisory_type"    => "$xml->{$advisory}->{type}",
@@ -465,8 +467,8 @@ foreach $advisory (sort(keys(%{$xml}))) {
                     "topic"            => "$xml->{$advisory}->{topic}",
                     "description"      => "$xml->{$advisory}->{description}",
                     "references"       => "$xml->{$advisory}->{references}",
-                    "notes"            => "$xml->{$advisory}->{notes}",
-                    "solution"         => "$xml->{$advisory}->{solution}" );
+                    "notes"            => "N/A",
+                    "solution"         => "$xml->{$advisory}->{solution}");
 
     # Insert description from Red Hat OVAL file, if available (only for Security)
     if (defined($ovalid)) {


### PR DESCRIPTION
hi,

I had already created the reboot_suggested part when I noticed you had already checked that stuff in.
But I see your code will place the keyword as an attribute inside  the USN-element which didn't work for me. So I have placed it inside its own <keywords> tag as a child element to the USN-element.

I have also found a problem with how Spacewalk retreives the package name from the debian packages metadata. I have a filed an issue here 
https://bugzilla.redhat.com/show_bug.cgi?id=1184946

I have taken the code from the Spacewalk server and placed it both in debUtils.py in the up2date_client aswell as in parseUbuntu.py in your project.

These changes have made me able to map all packages on serverside, clientside and errata to each other.
Feel free to use, or do better :)

Kr
Marcus