### PR TITLE
added support for "archive.canonical.com"

### DIFF
--- a/debianSync.py
+++ b/debianSync.py
@@ -60,6 +60,8 @@ match = re.search(r'(.*debian\/)', url) # Debian repos store data under 'debian/
 repoRoot = match.group(1) if match else repoRoot
 match = re.search(r'(.*security\.debian\.org\/)', url) # security.debian repo stores data in /
 repoRoot = match.group(1) if match else repoRoot
+match = re.search(r'(.*archive\.canonical\.com\/)', url) # Canonical archive repo stores data under /
+repoRoot = match.group(1) if match else repoRoot
 match = re.search(r'(.*postgresql.org\/pub\/repos\/apt\/)', url) # Postgres repos store data under 'pub/repos/apt/'
 repoRoot = match.group(1) if match else repoRoot
 


### PR DESCRIPTION
it works ;)

> 
> [root@spacewalk ~]# /usr/local/bin/debianSync.py --username xxxxxx --password 'xxxxxxxx' --channel 'ubuntu-1604-amd64-xenial-main' --url 'http://archive.canonical.com/dists/xenial/partner/binary-amd64/'
> INFO: Repo URL:  http://archive.canonical.com/dists/xenial/partner/binary-amd64/
> INFO: Repo root: http://archive.canonical.com/
> INFO: Packages in repo: 10
> INFO: Packages synced: 0
> INFO: Packages to sync: 10
> INFO: 1/10: skype_4.3.0.37-0ubuntu0.12.04.1_amd64.deb
> INFO: 2/10: adobe-flashplugin_20170214.1-0ubuntu0.16.04.1_amd64.deb
> INFO: 3/10: adobe-flash-properties-gtk_20170214.1-0ubuntu0.16.04.1_amd64.deb
> INFO: 4/10: adobe-flash-properties-kde_20170214.1-0ubuntu0.16.04.1_amd64.deb
> INFO: 5/10: gce-daemon_1.3.3-0ubuntu6~16.04.0_amd64.deb
> INFO: 6/10: gce-startup-scripts_1.3.3-0ubuntu6~16.04.0_amd64.deb
> INFO: 7/10: gce-imagebundle_1.3.2-0ubuntu1_amd64.deb
> INFO: 8/10: google-cloud-sdk_140.0.0-0ubuntu1~16.04.1_all.deb
> INFO: 9/10: gce-cloud-config_1.3.3-0ubuntu6~16.04.0_amd64.deb
> INFO: 10/10: gce-cloud-config_1.3.3-0ubuntu6~16.04.0_amd64.deb
> INFO: Sync complete
> 