### PR TITLE
 Fix split of lines in Packages.

### DIFF
--- a/debianSync.py
+++ b/debianSync.py
@@ -95,7 +95,7 @@ syncedPkgCount = 0
 for pkg in pkgs.split('\n\n'):
   repoPkgCount += 1
   for pkginfos in pkg.split('\n'):
-    line = pkginfos.split(':')
+    line = pkginfos.split(':',1)
     if line[0] == 'Filename': 
       filename = line[1].strip()
     elif line[0] == 'MD5sum':


### PR DESCRIPTION
 Otherwise version numbers with epochs get mangled, e.g. 1:2.11.0-3+deb9u4 will result in version 1.